### PR TITLE
Fix psucontrol helpers check + 1 more

### DIFF
--- a/octoprint_psucontrol_homeassistant/__init__.py
+++ b/octoprint_psucontrol_homeassistant/__init__.py
@@ -43,7 +43,7 @@ class PSUControl_HomeAssistant(octoprint.plugin.StartupPlugin,
 
     def on_startup(self, host, port):
         psucontrol_helpers = self._plugin_manager.get_helpers("psucontrol")
-        if 'register_plugin' not in psucontrol_helpers.keys():
+        if not psucontrol_helpers or 'register_plugin' not in psucontrol_helpers.keys():
             self._logger.warning("The version of PSUControl that is installed does not support plugin registration.")
             return
 

--- a/octoprint_psucontrol_homeassistant/templates/psucontrol_homeassistant_settings.jinja2
+++ b/octoprint_psucontrol_homeassistant/templates/psucontrol_homeassistant_settings.jinja2
@@ -1,3 +1,7 @@
+<!-- ko ifnot: settings.plugins.psucontrol -->
+<span class="help-inline label label-important">This plugin requires <a href="https://plugins.octoprint.org/plugins/psucontrol/" target="_blank">PSU Control</a> in order to function. It can be installed from the Plugin Manager.</span>
+<!-- /ko -->
+
 <form class="form-horizontal">
     <h4>General</h4>
     <div class="control-group">


### PR DESCRIPTION
This contains two commits. The first fixes a bug with the psucontrol helpers check that would throw an exception if PSUControl wasn't installed. Plugin would still display in settings so no harm done but figured it should be corrected.

The second adds a warning in settings if PSUControl is not installed or enabled.

Feel free to merge, cherry-pick, or close.