### PR TITLE
add ticket links to 'Automatically turn PSU ON' warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,10 @@ Adds Home Assistant support to OctoPrint-PSUControl as a sub-plugin
 - Install the plugin using Plugin Manager from Settings
 - Configure this plugin
 - Select this plugin as Switching *and* Sensing method in [PSU Control](https://github.com/kantlivelong/OctoPrint-PSUControl)
-- :warning: **Turn off** the *Automatically turn PSU ON* option in the PSU Control settings, leaving this on will ruin your prints when Home Assistant becomes unavailable :warning:
+- :warning: **Turn off** the *Automatically turn PSU ON* option in the PSU Control settings, leaving this on will ruin your prints when Home Assistant becomes unavailable :warning: (some explanation in tickets
+[#4](https://github.com/edekeijzer/OctoPrint-PSUControl-HomeAssistant/issues/4), 
+[#11](https://github.com/edekeijzer/OctoPrint-PSUControl-HomeAssistant/issues/11), 
+[#16](https://github.com/edekeijzer/OctoPrint-PSUControl-HomeAssistant/issues/16))
 
 ## Configuration
 * Enter the URL of your Home Assistant Installation


### PR DESCRIPTION
As I was reading the README, I wondered why turning on this flag was so bad. Looking at Issues, I found plenty explanation. This PR adds a few issue links so that others can also easily find this explanation.